### PR TITLE
use [auth =] instead of [cookie =] to authenticate

### DIFF
--- a/Scripts/Install/install-electrs-indexer.sh
+++ b/Scripts/Install/install-electrs-indexer.sh
@@ -14,7 +14,7 @@ fi
 # Retrieve bitcoind RPC credentials
 
 cat <<EOF > "${dojo_path_my_dojo}"/indexer/electrs.toml
-cookie = "$BITCOIND_RPC_USER:$BITCOIND_RPC_PASSWORD"
+auth = "$BITCOIND_RPC_USER:$BITCOIND_RPC_PASSWORD"
 server_banner = "Welcome to your RoninDojo ${ronindojo_version} Electrs Server!"
 EOF
 


### PR DESCRIPTION
Config files support 'auth' option to specify username and password. If you are using -rpcuser=USER and -rpcpassword=PASSWORD of bitcoind for authentication, please use auth="USER:PASSWORD" option in one of the config files.

https://github.com/flatcloud0b3/electrs/blob/master/doc/usage.md